### PR TITLE
Restart actor thread if it is killed/dies (e.g. on fork).

### DIFF
--- a/lib/async/actor/proxy.rb
+++ b/lib/async/actor/proxy.rb
@@ -50,8 +50,13 @@ module Async
 			protected
 			
 			def __kill__
-				@queue&.close
-				@thread&.join
+				@guard.synchronize do
+					@queue&.close
+					@queue = nil
+					
+					@thread&.kill
+					@thread = nil
+				end
 			end
 			
 			def __start__

--- a/lib/async/actor/proxy.rb
+++ b/lib/async/actor/proxy.rb
@@ -25,15 +25,15 @@ module Async
 			def initialize(target)
 				@target = target
 				
-				@queue = ::Thread::Queue.new
-				@thread = __start__
-				
-				# Define a finalizer to ensure the thread is closed:
-				::ObjectSpace.define_finalizer(self, Finalizer.new(@queue, @thread))
+				@queue = nil
+				@thread = nil
+				@guard = ::Thread::Mutex.new
 			end
 			
 			# @parameter return_value [Symbol] One of :ignore, :promise or :wait.
 			def method_missing(*arguments, return_value: :wait, **options, &block)
+				__start__
+				
 				unless return_value == :ignore
 					result = Variable.new
 				end
@@ -49,18 +49,35 @@ module Async
 			
 			protected
 			
+			def __kill__
+				@queue&.close
+				@thread&.join
+			end
+			
 			def __start__
-				::Thread.new do
-					::Kernel.Sync do |task|
-						while operation = @queue.pop
-							task.async do
-								arguments, options, block, result = operation
-								Variable.fulfill(result) do
-									@target.public_send(*arguments, **options, &block)
+				return if @thread&.alive?
+				
+				@guard.synchronize do
+					return if @thread&.alive?
+					
+					@queue&.close
+					@queue = ::Thread::Queue.new
+					
+					@thread = ::Thread.new do
+						::Kernel.Sync do |task|
+							while operation = @queue.pop
+								task.async do
+									arguments, options, block, result = operation
+									Variable.fulfill(result) do
+										@target.public_send(*arguments, **options, &block)
+									end
 								end
 							end
 						end
 					end
+					
+					# Define a finalizer to ensure the thread is closed:
+					::ObjectSpace.define_finalizer(self, Finalizer.new(@queue, @thread))
 				end
 			end
 		end

--- a/test/async/actor.rb
+++ b/test/async/actor.rb
@@ -6,4 +6,14 @@ describe Async::Actor do
 		
 		expect(actor).to be_a(Array)
 	end
+	
+	it "can restart actor if thread is killed" do
+		actor = Async::Actor.new(Array.new)
+		
+		expect(actor).to be_a(Array)
+		
+		actor.__send__(:__kill__)
+		
+		expect(actor).to be_a(Array)
+	end
 end


### PR DESCRIPTION
When forking, Ruby terminates all running threads. So we should (re)start the actor on demand. However, I wonder what happens to existing method calls...

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
